### PR TITLE
快捷自定义tag的类型

### DIFF
--- a/web/src/components/table/fieldRender/index.vue
+++ b/web/src/components/table/fieldRender/index.vue
@@ -287,6 +287,9 @@ const onButtonClick = (btn: OptButton) => {
 }
 
 const getTagType = (value: string, custom: any): TagProps['type'] => {
+    if (custom && custom['tagType']) {
+        return custom['tagType']
+    }
     return custom && custom[value] ? custom[value] : ''
 }
 </script>


### PR DESCRIPTION
当tag内容为自定义时（数量、内容不确定），不适合custom[value]方式设置type。
这样可以直接定义这些标签的type属性，多了一种选择。