### PR TITLE
Update TableManager.php

### DIFF
--- a/extend/ba/TableManager.php
+++ b/extend/ba/TableManager.php
@@ -123,7 +123,7 @@ class TableManager
 
         $table = Config::get('database.migration_table', 'migrations');
 
-        $dbConfig['default_migration_table'] = $dbConfig['table_prefix'] . $table;
+        $dbConfig['migration_table'] = $dbConfig['table_prefix'] . $table;
 
         return $dbConfig;
     }


### PR DESCRIPTION
修复升级Composer包以后, CRUD选择表时, 会出现如下错误的问题:
The default_migration_table setting for adapter has been deprecated since 0.13.0. Use migration_table instead.