### PR TITLE
自定义tag组件的type属性

### DIFF
--- a/web/src/components/table/fieldRender/index.vue
+++ b/web/src/components/table/fieldRender/index.vue
@@ -52,7 +52,7 @@
                 <el-tag
                     v-if="tag"
                     class="m-10"
-                    :type="getTagType(tag, field.custom)"
+                    :type="field.customTagType ?? getTagType(tag, field.custom)"
                     :effect="field.effect ?? 'light'"
                     :size="field.size ?? 'default'"
                 >
@@ -64,7 +64,7 @@
             <el-tag
                 class="m-10"
                 v-if="fieldValue !== ''"
-                :type="getTagType(fieldValue, field.custom)"
+                :type="field.customTagType ?? getTagType(fieldValue, field.custom)"
                 :effect="field.effect ?? 'light'"
                 :size="field.size ?? 'default'"
             >

--- a/web/types/table.d.ts
+++ b/web/types/table.d.ts
@@ -158,6 +158,8 @@ declare global {
         size?: TagProps['size']
         // 自定义数据:比如渲染为Tag时,可以指定不同值时的Tag的Type属性 { open: 'success', close: 'info' }
         custom?: any
+        // 自定义Tag的Type属性:当数据内容不确定时（例如用户手动输入），可以通过该字段指定Type属性。
+        customTagType?: TagProps['type'],
         // 谨慎使用：自定义渲染模板，方法可返回html内容，请确保返回内容是xss安全的
         customTemplate?: (row: TableRow, field: TableColumn, value: any, column: TableColumnCtx<TableRow>, index: number) => string
         // 自定义组件/函数渲染


### PR DESCRIPTION
如果Tag组件的内容是不确定的值时，比如由用户手动输入，可以通过 `customTagType: 'success'`  指定Type的属性。

eg:
敏感词管理功能，由用户手动输入具体的敏感词内容，table在展示的时候使用 tag 组件。


