### PR TITLE
fix:修复编辑时 unique 验证问题

### DIFF
--- a/app/admin/library/traits/Backend.php
+++ b/app/admin/library/traits/Backend.php
@@ -134,6 +134,8 @@ trait Backend
                     if (class_exists($validate)) {
                         $validate = new $validate;
                         if ($this->modelSceneValidate) $validate->scene('edit');
+                        $pk = $this->model->getPk();
+                        $data[$pk] = $row[$pk];
                         $validate->check($data);
                     }
                 }


### PR DESCRIPTION
模型验证器里面使用unique验证字段是否重复，正常情况下，编辑保存数据时需要排除当前修改的这条数据，验证时$data数据需要有主键才能排除当前修改的这条数据，否则在编辑时不修改任何数据的情况下保存，会提示重复。