### PR TITLE
优化图标Size参数支持number

### DIFF
--- a/web/src/components/icon/index.vue
+++ b/web/src/components/icon/index.vue
@@ -10,7 +10,7 @@ export default defineComponent({
             required: true,
         },
         size: {
-            type: String,
+            type: [String,Number],
             default: '18px',
         },
         color: {
@@ -21,7 +21,7 @@ export default defineComponent({
     setup(props) {
         const iconStyle = computed((): CSSProperties => {
             const { size, color } = props
-            let s = `${size.replace('px', '')}px`
+            let s = `${String(size).replace('px', '')}px`
             return {
                 fontSize: s,
                 color: color,

--- a/web/src/components/icon/svg/index.vue
+++ b/web/src/components/icon/svg/index.vue
@@ -10,7 +10,7 @@ import { computed, type CSSProperties } from 'vue'
 import { isExternal } from '/@/utils/common'
 interface Props {
     name: string
-    size: string
+    size: string | number
     color: string
 }
 
@@ -20,7 +20,7 @@ const props = withDefaults(defineProps<Props>(), {
     color: '#000000',
 })
 
-const s = `${props.size.replace('px', '')}px`
+const s = `${String(props.size).replace('px', '')}px`
 const iconName = computed(() => `#${props.name}`)
 const iconStyle = computed((): CSSProperties => {
     return {


### PR DESCRIPTION
size 参数必须为string 不太友好
![image](https://github.com/user-attachments/assets/6a3972c5-2b64-46bb-9bdf-077b4ab8c78d)
大多数图片组件亦是如此故修改
