### PR TITLE
Update remoteSelect.vue

### DIFF
--- a/web/src/components/baInput/components/remoteSelect.vue
+++ b/web/src/components/baInput/components/remoteSelect.vue
@@ -54,7 +54,7 @@
                             :layout="props.paginationLayout"
                             :total="state.total"
                             @current-change="onSelectCurrentPageChange"
-                            :small="config.layout.shrink"
+                            :size="config.layout.shrink ? 'small' : 'default'"
                         />
                     </template>
                 </el-select>


### PR DESCRIPTION
修复 remoteSelect.vue:232 ElementPlusError: [el-pagination] [API] small is about to be deprecated in version 3.0.0, please use size instead.
For more detail, please visit: https://element-plus.org/zh-CN/component/pagination.html