### PR TITLE
Update Upload.php

### DIFF
--- a/app/common/library/Upload.php
+++ b/app/common/library/Upload.php
@@ -254,7 +254,7 @@ class Upload
 
         // 图片文件利用tp内置规则做一些额外检查
         if ($this->checkIsImage()) {
-            $fileValidateRule->image("{$this->fileInfo['width']},{$this->fileInfo['height']},{$this->fileInfo['suffix']}", __('The uploaded image file is not a valid image'));
+            $fileValidateRule->image("{$this->fileInfo['width']},{$this->fileInfo['height']}", __('The uploaded image file is not a valid image'));
         }
 
         Validate::failException()


### PR DESCRIPTION
修复 微信截图无法上传的问题，
问题触发原因： 微信截图 后缀为png，实际mime格式为 image/jpeg
这种图片在实际使用中也是比较常见的，
tp内置的image规则 会拒绝该类型图片，取消了image中针对 type的验证