### PR TITLE
baTable相关优化

### DIFF
--- a/web/src/components/table/fieldRender/buttons.vue
+++ b/web/src/components/table/fieldRender/buttons.vue
@@ -10,6 +10,7 @@
                     :class="btn.class"
                     class="ba-table-render-buttons-item"
                     :type="btn.type"
+                    :loading="btn.loading && btn.loading(row, field)"
                     :disabled="btn.disabled && btn.disabled(row, field)"
                     v-bind="btn.attr"
                 >
@@ -31,6 +32,7 @@
                         :class="btn.class"
                         class="ba-table-render-buttons-item"
                         :type="btn.type"
+                        :loading="btn.loading && btn.loading(row, field)"
                         :disabled="btn.disabled && btn.disabled(row, field)"
                         v-bind="btn.attr"
                     >
@@ -42,6 +44,7 @@
                 <!-- 带确认框的按钮 -->
                 <el-popconfirm
                     v-if="btn.render == 'confirmButton' && ((btn.name == 'delete' && baTable.auth('del')) || btn.name != 'delete')"
+                    :loading="btn.loading && btn.loading(row, field)"
                     :disabled="btn.disabled && btn.disabled(row, field)"
                     v-bind="btn.popconfirm"
                     @confirm="onButtonClick(btn)"
@@ -59,6 +62,7 @@
                                     :class="btn.class"
                                     class="ba-table-render-buttons-item"
                                     :type="btn.type"
+                                    :loading="btn.loading && btn.loading(row, field)"
                                     :disabled="btn.disabled && btn.disabled(row, field)"
                                     v-bind="btn.attr"
                                 >
@@ -82,6 +86,7 @@
                         :class="btn.class"
                         class="ba-table-render-buttons-item move-button"
                         :type="btn.type"
+                        :loading="btn.loading && btn.loading(row, field)"
                         :disabled="btn.disabled && btn.disabled(row, field)"
                         v-bind="btn.attr"
                     >

--- a/web/src/utils/baTable.ts
+++ b/web/src/utils/baTable.ts
@@ -497,10 +497,10 @@ export default class baTable {
         if (this.table.acceptQuery && !isEmpty(route.query)) {
             // 根据当前 URL 的 query 初始化公共搜索默认值
             this.setComSearchData(route.query)
-
-            // 获取公共搜索数据合并至表格筛选条件
-            this.table.filter!.search = this.getComSearchData().concat(this.table.filter?.search ?? [])
         }
+
+        // 获取公共搜索数据合并至表格筛选条件
+        this.table.filter!.search = this.getComSearchData().concat(this.table.filter?.search ?? [])
     }
 
     /**
@@ -546,7 +546,7 @@ export default class baTable {
             }
         }
 
-        this.comSearch.form = Object.assign(this.comSearch.form, form)
+        this.comSearch.form = Object.assign(form, this.comSearch.form)
     }
 
     /**

--- a/web/types/table.d.ts
+++ b/web/types/table.d.ts
@@ -393,6 +393,13 @@ declare global {
         disabled?: (row: TableRow, field: TableColumn) => boolean
 
         /**
+         * 按钮点击是否在加载中（请返回布尔值）
+         * @param row 当前行数据
+         * @param field 当前列数据
+         */
+        loading?: (row: TableRow, field: TableColumn) => boolean
+
+        /**
          * 自定义 el-button 的其他属性
          */
         attr?: Partial<Mutable<ButtonProps>>


### PR DESCRIPTION
1.修改initComSearch合并form的先后顺序.以保证初始化前可以使用setComSearchData,保证首屏加载数据搜索条件生效
2.修改mount中对于filter!.search的合并,保证setComSearchData与原始数据能有效合并生效
3.对baTable的buttons组件所有按钮增加loading控制函数